### PR TITLE
Fix reversed logic for "Set Swap Priority above Zram?" option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you find this module useful, please consider starring the repository on GitHu
 
 ## Contribution
 Fork this repository, create a new branch (example - dev/feature-name) and commit your changes, test and verify if they are functional.
-Once you confirm, please open a pull request from your forked branch to the source branch and assign @janithcooray to review. Will be testing them manually before merging it.
+Once you confirm, please open a pull request from your forked branch to the source branch and assign @janithcooray to review. I'll be testing them manually before merging it.
 
 ## Issues
 If you encounter any issues, please open an issue from GitHub at https://github.com/janithcooray/lin_os_swap_mod/issues/new i will try to patch them asap.

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,7 @@
-rm module.zip
+#! /bin/zsh
+rm -f module.zip
+rm -f lin_os_swap_mod.zip
+rm -f swapfile_mod.zip
 7z a module.zip module/.
+cp module.zip lin_os_swap_mod.zip
+cp module.zip swapfile_mod.zip

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -50,11 +50,11 @@ function ask_zram_prior(){
 # Create Swapfile
 function create_swapfile(){
     ui_print "- Trying to stop Existing Swapfile"
-    ui_print "  (This can take a few minutes, do not panic if it looks stuck)"
+    ui_print "  (This can take a long time, do not panic if it looks stuck)"
     swapoff /data/swap/swapfile
     rm -rf /data/swap
     mkdir /data/swap
-    ui_print "- Crating a swapfile of $SWAP_BIN_SIZE MB"
+    ui_print "- Creating a swapfile of $SWAP_BIN_SIZE MB"
     ui_print "  This can take a minute or two"
     cd /data/swap && dd if=/dev/zero of=swapfile bs=1048576 count=$SWAP_BIN_SIZE
     ui_print "- Empty File for Swap of size $SWAP_BIN_SIZE MB Created!!"

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -40,10 +40,10 @@ function ask_zram_prior(){
     ui_print "   Vol Down += No "
     if $VKSEL; then
         ui_print "  Setting to 0"
-        OVER_ZRAM_PRIOR=0
+        OVER_ZRAM_PRIOR=1
     else
         ui_print "  Setting to auto"
-        OVER_ZRAM_PRIOR=1
+        OVER_ZRAM_PRIOR=0
     fi
 }
 

--- a/module/module.prop
+++ b/module/module.prop
@@ -1,7 +1,7 @@
 id=lin_os_swap_mod
 name=Lineage OS SWAP mod
-version=v1.2
-versionCode=3
+version=v1.3.1
+versionCode=6
 author=janithcooray
 description=Enable / Change Swap config for Android 7+
 template=3


### PR DESCRIPTION
This was caused by commit https://github.com/janithcooray/lin_os_swap_mod/commit/84440c9f969341a65478003c07911a714c8169df and is related to issue https://github.com/janithcooray/lin_os_swap_mod/issues/10. OVER_ZRAM_PRIOR's values in customize.sh were reversed from what they should be, so answering 'Yes' would not set the swapfile's priority to 0 as expected.