### PR TITLE
Fix reversed logic for 'Set Swap Priority above Zram?' option

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,7 +3,7 @@
 github: [janithcooray]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
-ko_fi: https://ko-fi.com/janithcooray
+ko_fi: janithcooray
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,7 +3,7 @@
 github: [janithcooray]
 patreon: # Replace with a single Patreon username
 open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
+ko_fi: https://ko-fi.com/janithcooray
 tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 liberapay: # Replace with a single Liberapay username

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ once you confirm, please open a pull request from your forked branch to the sour
 if you encounter any issues, please open an issue from GitHub at https://github.com/janithcooray/lin_os_swap_mod/issues/new i will try to patch them asap.
 
 ## Update
-`2024-02-10` (Scheduled) - Version `2.0` - Adding App to manage Config and separate Prebuilt Configs on install + Bug fixes
+`2024-03-10` (Pending) - Version `2.0` - Adding App to manage Config and separate Prebuilt Configs on install + Bug fixes
 
 `2023-10-15` - Version `1.3` - Increased Swappiness to fix usage issues
 

--- a/module/customize.sh
+++ b/module/customize.sh
@@ -40,10 +40,10 @@ function ask_zram_prior(){
     ui_print "   Vol Down += No "
     if $VKSEL; then
         ui_print "  Setting to 0"
-        OVER_ZRAM_PRIOR=0
+        OVER_ZRAM_PRIOR=1
     else
         ui_print "  Setting to auto"
-        OVER_ZRAM_PRIOR=1
+        OVER_ZRAM_PRIOR=0
     fi
 }
 


### PR DESCRIPTION
This was caused by commit https://github.com/janithcooray/lin_os_swap_mod/commit/84440c9f969341a65478003c07911a714c8169df and is related to issue https://github.com/janithcooray/lin_os_swap_mod/issues/10. OVER_ZRAM_PRIOR's values in customize.sh were reversed from what they should be, so answering 'Yes' would not set the swapfile's priority to 0 as expected.

This pull request is the same as #16, but only contains the changes related to ZRAM priority logic, without commits from other PRs.