### PR TITLE
Use zip command instead of 7zip and exit on fail

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,12 @@
-#! /bin/zsh
+#!/bin/sh
+
+set -eu
+
 rm -f module.zip
 rm -f lin_os_swap_mod.zip
 rm -f swapfile_mod.zip
-7z a module.zip module/.
+
+(cd module && zip -r ../module.zip .)
+
 cp module.zip lin_os_swap_mod.zip
 cp module.zip swapfile_mod.zip


### PR DESCRIPTION
- `zip` is more commonly available than `7zip`.
- `set -eu` tells the shell to stop the execution of the script if a step failed (for example the zip command).
